### PR TITLE
Dev atomic write

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 # Last Updated 11-04-2016	
 
 Simple-Store
++ 3.1.0
+  use atomic-write to handle file writing
 + 3.0.0
   removed close store  
 + 2.1.0

--- a/simple-store.cabal
+++ b/simple-store.cabal
@@ -32,7 +32,7 @@ Library
                       , safe >= 0.3.8
                       , bifunctors >= 4.2
                       , time >= 1.4.2
-                      , atomic-write
+                      , atomic-write >= 0.2.0.5
 
 Test-Suite spec
   Type:                 exitcode-stdio-1.0
@@ -54,6 +54,7 @@ Test-Suite spec
                       , bifunctors
                       , time
                       , async
+                      , atomic-write
 
 Test-Suite mem-spec
   Type:                 exitcode-stdio-1.0
@@ -76,6 +77,7 @@ Test-Suite mem-spec
                       , bifunctors
                       , time
                       , async
+                      , atomic-write
 
 
 benchmark simple-store-bench
@@ -110,6 +112,7 @@ benchmark simple-store-bench
                       , bifunctors
                       , time
                       , async
+                      , atomic-write
 
 
   Ghc-Options:          -threaded -Wall  -rtsopts -prof -auto-all

--- a/simple-store.cabal
+++ b/simple-store.cabal
@@ -1,5 +1,5 @@
 Name:                   simple-store
-Version:                3.0.1
+Version:                3.1.0
 Author:                 Kevin Cotrone <kevincotrone@gmail.com>
 Maintainer:             Kevin Cotrone <kevincotrone@gmail.com>
 License:                BSD3

--- a/simple-store.cabal
+++ b/simple-store.cabal
@@ -32,7 +32,7 @@ Library
                       , safe >= 0.3.8
                       , bifunctors >= 4.2
                       , time >= 1.4.2
-                      , async
+                      , atomic-write
 
 Test-Suite spec
   Type:                 exitcode-stdio-1.0

--- a/src/SimpleStore/IO.hs
+++ b/src/SimpleStore/IO.hs
@@ -44,6 +44,10 @@ import SimpleStore.FileIO
 import SimpleStore.Internal
 import SimpleStore.Types
 
+import System.AtomicWrite.Writer.ByteString
+
+import Filesystem.Path.CurrentOS (encodeString)
+
 -- | Get the current value of the store
 getSimpleStore :: SimpleStore st -> IO st
 getSimpleStore store = atomically . readTVar . storeState $ store
@@ -121,8 +125,8 @@ makeSimpleStore dir state = do
          (unpack checkpointBaseFileName) -- we write a backup immediately
          )
       initialVersion = 0
-  writeFile checkpointPath encodedState
-  writeFile checkpointPathBackup encodedState
+  atomicWriteFile (encodeString checkpointPath) encodedState
+  atomicWriteFile (encodeString checkpointPathBackup) encodedState
   Right <$> createStore fp (1 + initialVersion) state
 
 -- | Attempt to open a store. If the store doesn't it exist it will create the store in the filepath given


### PR DESCRIPTION
The changes use atomic-write to ensure that the files are only ever replaced after they have been written to disk. This is done by writing to a temp file and after writing, moving the file (an atomic operation).