### PR TITLE
Propagate initialization error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,11 @@
 # Changelog
 
-# Last Updated 11-04-2016	
+# Last Updated 2017-9-28
 
 Simple-Store
++ 4.1.0
+  Shor-circuit `openNewestStore` to return the correct `StoreError` value when
+  there is deserialization error.
 + 4.0.0
   Export STM versions of many functions
 + 3.1.0
@@ -10,18 +13,18 @@ Simple-Store
 + 3.0.1
   add modifySimpleStoreResultWith
 + 3.0.0
-  removed close store  
+  removed close store
 + 2.1.0
   removed Handle holding
 + 2.0.4
   open.lock functionality removed
   made fsync run inbetweeen var locks to force it better
-	
+
 + 2.0.3
   fsync on checkpoints and locks
   createCheckpointImmediate allows fsync to be called optionally.
   immediate checkpoints always on lock files
-	
+
 + 2.0.2
    better exception handling in opening state store.
    Separated out different try/catch places
@@ -40,7 +43,7 @@ Simple-Store
 + 1.0.0
 	We went down an odd path in 0.3.0 - 0.2.0
 	This restores order
-	
+
 + 0.1.4
   Better filename creation routine
   More strictness in the base types

--- a/simple-store.cabal
+++ b/simple-store.cabal
@@ -1,5 +1,5 @@
 Name:                   simple-store
-Version:                4.0.0
+Version:                4.1.0
 Author:                 Kevin Cotrone <kevincotrone@gmail.com>
 Maintainer:             Kevin Cotrone <kevincotrone@gmail.com>
 License:                BSD3

--- a/src/SimpleStore/FileIO.hs
+++ b/src/SimpleStore/FileIO.hs
@@ -59,7 +59,9 @@ openNewestStore f (x:xs) = do
     Left e ->
       putStrLn "errors found and written to errors.log" >>
       (appendFile ("errors-in-" ++ (encodeString . dirname) x ++ ".log") ("filePath:" ++ show x ++ "\n error: " ++ show e)) >>
-      openNewestStore f (Prelude.filter (not . (== x)) xs)
+      case e of
+        err@(StoreIOError _) -> return . Left $ err
+        _otherwise           -> openNewestStore f (Prelude.filter (not . (== x)) xs)
     _ -> return res
   where
     hIOException
@@ -69,7 +71,7 @@ openNewestStore f (x:xs) = do
       -> IO (Either StoreError b)
     hIOException func ys e =
       hPrint stderr e >> openNewestStore func (Prelude.filter (not . (== x)) ys)
-    
+
 
 
 -- Attempt to open a store from a filepath
@@ -183,14 +185,14 @@ readLastTouch dir failoverAction = performRead >>=
   where
     lastTouch = dir </> "last.touch"
     decodeResult               = (>>= first decodeFileError  . decodeUtf8') . first readFileError
-    
+
     evaluateResult (Left  err) = recordError err *> failoverAction
     evaluateResult (Right txt) = return . fromText $ txt
-    
-    recordError     e = appendFile ("errors-in-"++ (encodeString . dirname) lastTouch  ++ ".log") ("filePath:" ++ show  lastTouch  ++ "\n error: " ++ show e)    
+
+    recordError     e = appendFile ("errors-in-"++ (encodeString . dirname) lastTouch  ++ ".log") ("filePath:" ++ show  lastTouch  ++ "\n error: " ++ show e)
     readFileError   e =  "error reading file "         ++ show e
     decodeFileError e =  "error parsing text of file " ++ show e
-    
+
     performRead = do
            let stringFilePath = encodeString lastTouch  :: String -- Create the full filepath for last.touch
            try $ BS.readFile stringFilePath :: IO (Either SomeException BS.ByteString)

--- a/src/SimpleStore/FileIO.hs
+++ b/src/SimpleStore/FileIO.hs
@@ -48,7 +48,11 @@ import System.AtomicWrite.Writer.ByteString
 -- --------------------------------------------------
 -- API
 -- --------------------------------------------------
--- | Opens the newest store that doesn't throw an exception or give a StoreError back as a result
+
+-- | Opens the newest store that doesn't throw an exception or give a StoreError back as a result.
+-- Attempts to recursively read the second latest touched file if the latest touched file is not found.
+-- For case of corrupted data like serialization error, instead of retrying the next file,
+-- we immediately return with 'StoreIOError'.
 openNewestStore :: (FilePath -> IO (Either StoreError b))
                 -> [FilePath]
                 -> IO (Either StoreError b)


### PR DESCRIPTION
Short-circuit `openNewestStore` function to return early if there is serialization issue. Serialization issue is carried by `StoreIOError`. For any other errors, we continue with current behavior.